### PR TITLE
Attempt to fix logstash warnings.

### DIFF
--- a/logstash/pipeline/20-filter.conf
+++ b/logstash/pipeline/20-filter.conf
@@ -14,68 +14,68 @@ filter {
 # Drop everything that is not one of these UDP amplification ports
    if
    # QOTD https://www.shadowserver.org/what-we-do/network-reporting/open-qotd-report/
-   [destination][port] != 17 and
+   [target][port] != 17 and
    # CharGen https://www.shadowserver.org/what-we-do/network-reporting/open-chargen-report/
-   [destination][port] != 19 and
+   [target][port] != 19 and
    # DNS https://www.shadowserver.org/what-we-do/network-reporting/dns-open-resolvers-report/
-   [destination][port] != 53 and
+   [target][port] != 53 and
    # TFTP https://www.shadowserver.org/what-we-do/network-reporting/open-accessible-tftp-report/
-   [destination][port] != 69 and
+   [target][port] != 69 and
    # Portmapper: https://www.shadowserver.org/what-we-do/network-reporting/open-portmapper-report/
-   [destination][port] != 111 and
+   [target][port] != 111 and
    # NTP version https://www.shadowserver.org/what-we-do/network-reporting/ntp-version-report/ 
    # and NTP monlist https://www.shadowserver.org/what-we-do/network-reporting/ntp-monitor-report/
-   [destination][port] != 123 and
+   [target][port] != 123 and
    # NetBIOS https://www.shadowserver.org/what-we-do/network-reporting/open-netbios-report/
-   [destination][port] != 137 and
+   [target][port] != 137 and
    # SNMP https://www.shadowserver.org/what-we-do/network-reporting/open-snmp-report/
-   [destination][port] != 161 and
+   [target][port] != 161 and
    # XDMCP https://www.shadowserver.org/what-we-do/network-reporting/accessible-xdmcp-service-report/
-   [destination][port] != 177 and
+   [target][port] != 177 and
    # LDAP https://www.shadowserver.org/what-we-do/network-reporting/open-ldap-report/
-   [destination][port] != 389 and
+   [target][port] != 389 and
    # RIP https://blogs.akamai.com/2015/07/ripv1-reflection-ddos-making-a-comeback.html
-   [destination][port] != 520 and
+   [target][port] != 520 and
    # DB2 https://www.shadowserver.org/what-we-do/network-reporting/open-db2-discovery-service-report/
-   [destination][port] != 523 and
+   [target][port] != 523 and
    # MS-SQL https://www.shadowserver.org/what-we-do/network-reporting/open-ms-sql-server-resolution-service-report/
-   [destination][port] != 1434 and
+   [target][port] != 1434 and
    # SSDP https://www.shadowserver.org/what-we-do/network-reporting/open-ssdp-report/
-   [destination][port] != 1900 and
+   [target][port] != 1900 and
    # ARD https://www.shadowserver.org/what-we-do/network-reporting/accessible-apple-remote-desktop-ard-report/
-   [destination][port] != 3283 and
+   [target][port] != 3283 and
    # RDP https://www.shadowserver.org/what-we-do/network-reporting/accessible-ms-rdpeudp/
-   [destination][port] != 3389 and
+   [target][port] != 3389 and
    # WSD https://github.com/Phenomite/AMP-Research/tree/master/Port%203702%20-%20WSD
-   [destination][port] != 3702 and
+   [target][port] != 3702 and
    # Sentinel https://github.com/Phenomite/AMP-Research/tree/master/Port%205093%20-%20Sentinel
-   [destination][port] != 5093 and
+   [target][port] != 5093 and
    # mDNS https://www.shadowserver.org/what-we-do/network-reporting/open-mdns-report/
-   [destination][port] != 5353 and
+   [target][port] != 5353 and
    # CoAP https://www.shadowserver.org/what-we-do/network-reporting/accessible-coap-report/
-   [destination][port] != 5683 and
+   [target][port] != 5683 and
    # Ubiquiti https://www.shadowserver.org/what-we-do/network-reporting/open-ubiquiti-report/
-   [destination][port] != 10001 and
+   [target][port] != 10001 and
    # Memcached https://www.shadowserver.org/what-we-do/network-reporting/open-memcached-report/
-   [destination][port] != 11211 and
+   [target][port] != 11211 and
    # Plex https://www.shadowserver.org/what-we-do/network-reporting/open-ssdp-report/
-   [destination][port] != 32414
+   [target][port] != 32414
    {
        drop { }
    }
 
 # Drop real DNS traffic
-   if [source][port] == 53 and [destination][port] == 53 {
+   if [source][port] == 53 and [target][port] == 53 {
       drop { }
    }
 
 # Drop real NTP traffic
-   if [source][port] == 123 and [destination][port] == 123 {
+   if [source][port] == 123 and [target][port] == 123 {
       drop { }
    }
 
 # Drop real L2TP traffic
-   if [source][port] == 1701 and [destination][port] == 1701 {
+   if [source][port] == 1701 and [target][port] == 1701 {
       drop { }
    }
 

--- a/logstash/pipeline/30-shadowserver.conf
+++ b/logstash/pipeline/30-shadowserver.conf
@@ -1,169 +1,169 @@
 filter {
 
-  if [destination][port] == 17  {
+  if [target][port] == 17  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/qotd.yml'
      }
   }
 
-  if [destination][port] == 19  {
+  if [target][port] == 19  {
      translate {
-        field => "[destination][ip]"
-         destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+         target => "[netflow][open_udp]"
          dictionary_path => '/usr/share/logstash/tattle-tale/chargen.yml'
      }
   }
 
-  if [destination][port] == 53  {
+  if [target][port] == 53  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/dns.yml'
      }
   }
 
-  if [destination][port] == 69  {
+  if [target][port] == 69  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/tftp.yml'
      }
   }
 
-  if [destination][port] == 111  {
+  if [target][port] == 111  {
     translate {
-       field => "[destination][ip]"
-       destination => "[netflow][open_udp]"
+       source => "[target][ip]"
+       target => "[netflow][open_udp]"
        dictionary_path => '/usr/share/logstash/tattle-tale/portmapper.yml'
      }
   }
 
-  if [destination][port] == 123  {
+  if [target][port] == 123  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/ntp.yml'
      }
   }
 
-  if [destination][port] == 123  {
+  if [target][port] == 123  {
      translate {
-        field => "[destination][ip]"
-         destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+         target => "[netflow][open_udp]"
          dictionary_path => '/usr/share/logstash/tattle-tale/ntpmonitor.yml'
      }
   }
 
-  if [destination][port] == 137  {
+  if [target][port] == 137  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/netbios.yml'
      }
   }
 
-  if [destination][port] == 161  {
+  if [target][port] == 161  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/snmp.yml'
      }
   }
 
-  if [destination][port] == 177  {
+  if [target][port] == 177  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/xdmcp.yml'
      }
   }
 
-  if [destination][port] == 389  {
+  if [target][port] == 389  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/ldap.yml'
      }
   }
  
- if [destination][port] == 523  {
+ if [target][port] == 523  {
     translate {
-       field => "[destination][ip]"
-       destination => "[netflow][open_udp]"
+       source => "[target][ip]"
+       target => "[netflow][open_udp]"
        dictionary_path => '/usr/share/logstash/tattle-tale/db2.yml'
      }
   }
 
-  if [destination][port] == 1434  {
+  if [target][port] == 1434  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/mssql.yml'
      }
   }
 
-  if [destination][port] == 1900  {
+  if [target][port] == 1900  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/ssdp.yml'
      }
   }
 
-  if [destination][port] == 3283  {
+  if [target][port] == 3283  {
      translate {
-        field => "[destination][ip]"
-         destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+         target => "[netflow][open_udp]"
          dictionary_path => '/usr/share/logstash/tattle-tale/ard.yml'
      }
   }
 
-  if [destination][port] == 3389  {
+  if [target][port] == 3389  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/rdpeudp.yml'
      }
   }
 
-  if [destination][port] == 5353  {
+  if [target][port] == 5353  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/mdns.yml'
      }
   }
 
-  if [destination][port] == 5683  {
+  if [target][port] == 5683  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/coap.yml'
      }
   }
 
-  if [destination][port] == 10001  {
+  if [target][port] == 10001  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/ubiquiti.yml'
      }
   }
 
-  if [destination][port] == 11211  {
+  if [target][port] == 11211  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/memcached.yml'
      }
   }
 
-  if [destination][port] == 32414  {
+  if [target][port] == 32414  {
      translate {
-        field => "[destination][ip]"
-        destination => "[netflow][open_udp]"
+        source => "[target][ip]"
+        target => "[netflow][open_udp]"
         dictionary_path => '/usr/share/logstash/tattle-tale/ssdp.yml'
      }
   }
@@ -172,9 +172,9 @@ filter {
 # as an open UDP amplifier by Shadowserver or one of the other amp ports, drop it.
 # This can reduce false positives but leave out some true positives 
   if ![netflow][open_udp] and 
-  [destination][port] != 520 and
-  [destination][port] != 3702 and
-  [destination][port] != 5093
+  [target][port] != 520 and
+  [target][port] != 3702 and
+  [target][port] != 5093
   {
      drop{ }
   }

--- a/logstash/pipeline/30-src-80-443.conf.disabled
+++ b/logstash/pipeline/30-src-80-443.conf.disabled
@@ -10,18 +10,18 @@ filter {
    #if [source][port] != 80 and [source][port] != 443 {
    if [source][port] == 80 or [source][port] == 443 {
       if 
-      [destination][port] != 17 and
-      [destination][port] != 19 and 
-      [destination][port] != 53 and 
-      [destination][port] != 69 and 
-      [destination][port] != 111 and
-      [destination][port] != 123 and 
-      [destination][port] != 137 and 
-      [destination][port] != 161 and 
-      [destination][port] != 177 and
-      [destination][port] != 389 and
-      [destination][port] != 520 and
-      [destination][port] != 523
+      [target][port] != 17 and
+      [target][port] != 19 and
+      [target][port] != 53 and
+      [target][port] != 69 and
+      [target][port] != 111 and
+      [target][port] != 123 and
+      [target][port] != 137 and
+      [target][port] != 161 and
+      [target][port] != 177 and
+      [target][port] != 389 and
+      [target][port] != 520 and
+      [target][port] != 523
       {
         drop { }
       }

--- a/logstash/pipeline/40-ifName.conf
+++ b/logstash/pipeline/40-ifName.conf
@@ -8,8 +8,8 @@ filter {
       translate {
         id => "netflow_postproc_translate_input_ifname"
         dictionary_path => "/usr/share/logstash/tattle-tale/ifName.yml"
-        field => "[@metadata][in_if_key]"
-        destination => "[netflow][input_ifname]"
+        source => "[@metadata][in_if_key]"
+        target => "[netflow][input_ifname]"
         fallback => "index: %{[netflow][ingress_interface]}"
         refresh_behaviour => "replace"
       }

--- a/logstash/pipeline/50-reverse-dns.conf
+++ b/logstash/pipeline/50-reverse-dns.conf
@@ -15,14 +15,14 @@ filter {
             failed_cache_ttl => "3600"
         }
     }
-    if [destination][ip] {
+    if [target][ip] {
         mutate {
             id => "destination_hostname"
-            add_field => {"[destination][hostname]" => "%{[destination][ip]}"}
+            add_field => {"[target][hostname]" => "%{[target][ip]}"}
         }
         dns {
             id => "netflow_dns_destination_name"
-            reverse => [ "[destination][hostname]" ]
+            reverse => [ "[target][hostname]" ]
             action => "replace"
             nameserver => "8.8.8.8"
             hit_cache_size => "25000"

--- a/logstash/pipeline/60-service-type.conf
+++ b/logstash/pipeline/60-service-type.conf
@@ -1,22 +1,22 @@
-# This filter will apply service types to the records based on the destination hostname
+# This filter will apply service types to the records based on the target hostname
 # Please change the regex to match your hostname naming convention
 # If not needed, this can be disabled 
 
 filter {
 
-    if [destination][hostname] =~ /\.biz\./ or [destination][hostname] =~ /\.static\./ {
+    if [target][hostname] =~ /\.biz\./ or [target][hostname] =~ /\.static\./ {
         mutate {
             add_field=>["netflow.dst_service_type", "business"]
         }
     }
 
-    if [destination][hostname] =~ /\.res\./ or [destination][hostname] =~ /\.dhcp\./ {
+    if [target][hostname] =~ /\.res\./ or [target][hostname] =~ /\.dhcp\./ {
         mutate {
             add_field=>["netflow.dst_service_type", "residential"]
         }
     }
 
-    if [destination][hostname] =~ /mta-/ {
+    if [target][hostname] =~ /mta-/ {
         mutate {
             add_field=>["netflow.dst_service_type", "mta"]
         }


### PR DESCRIPTION
This change is an attempt to address these errors in the log:

[2022-05-11T03:18:02,273][WARN ][logstash.filters.translate] You are using a deprecated config setting "field" set in translate. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Use `source` option instead. If you have any questions about this, please visit the #logstash channel on freenode irc. {:name=>"field", :plugin=><LogStash::Filters::Translate destination=>"[netflow][open_udp]", dictionary_path=>"/usr/share/logstash/tattle-tale/ubiquiti.yml", id=>"f1ac8bd939f685c8929f1eaaef1625a22b0023764959faeda5ceded85fde72be", field=>"[destination][ip]", enable_metric=>true, periodic_flush=>false, refresh_interval=>300, exact=>true, regex=>false, refresh_behaviour=>"merge">}

[2022-05-11T03:18:02,279][WARN ][logstash.filters.translate] You are using a deprecated config setting "destination" set in translate. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Use `target` option instead. If you have any questions about this, please visit the #logstash channel on freenode irc. {:name=>"destination", :plugin=><LogStash::Filters::Translate destination=>"[netflow][open_udp]", dictionary_path=>"/usr/share/logstash/tattle-tale/memcached.yml", id=>"47f44ac52b2d476bdc96e8d42b1d8442365041966ea7a8dfc4d8fccf270e0939", field=>"[destination][ip]", enable_metric=>true, periodic_flush=>false, refresh_interval=>300, exact=>true, regex=>false, refresh_behaviour=>"merge">}

[2022-05-11T03:18:08,812][WARN ][deprecation.logstash.filters.translate][main] `field` option is deprecated; use `source` instead.
[2022-05-11T03:18:08,819][WARN ][deprecation.logstash.filters.translate][main] `destination` option is deprecated; use `target` instead.