### PR TITLE
Attempt to fix logstash_internal permissions

### DIFF
--- a/setup/roles/logstash_writer.json
+++ b/setup/roles/logstash_writer.json
@@ -9,7 +9,8 @@
       "names": [
         "logs-generic-default",
         "logstash-*",
-        "ecs-logstash-*"
+        "ecs-logstash-*",
+        "netflow-*"
       ],
       "privileges": [
         "write",


### PR DESCRIPTION
This is an attempt to address this error:

error=>{"type"=>"security_exception", "reason"=>"action [indices:data/write/bulk[s]] is unauthorized for user [logstash_internal] with roles [logstash_writer] on indices [netflow-2022.05.11], this action is granted by the index privileges [create_doc,create,delete,index,write,all]"}

